### PR TITLE
celocli 6.1.0

### DIFF
--- a/Formula/a/aescrypt-packetizer.rb
+++ b/Formula/a/aescrypt-packetizer.rb
@@ -7,10 +7,6 @@ class AescryptPacketizer < Formula
   sha256 "e2e192d0b45eab9748efe59e97b656cc55f1faeb595a2f77ab84d44b0ec084d2"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    skip "v4 is under a commercial license"
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "1039232a96b3efc3d8c4a1da6d48d8d37cc2991e8275dc467d0b8b16229ead5c"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d840ff8d10cb48274d58dac6bc26126ceba767c36e56b2e9e24f2b591dccca0d"
@@ -25,13 +21,9 @@ class AescryptPacketizer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3eddb8372fd630b7f93288f2fb19c3ec96a061b1de150918bee53d0a7a1d55ee"
   end
 
-  head do
-    url "https://github.com/paulej/AESCrypt.git", branch: "master"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
+  # v3 source code has been unavailable since at least 2024-09-01.
+  # v4 requires purchase of license (https://www.aescrypt.com/license.html)
+  deprecate! date: "2025-03-17", because: "switched to a commercial license in v4"
 
   def install
     if build.head?

--- a/Formula/c/celocli.rb
+++ b/Formula/c/celocli.rb
@@ -1,0 +1,54 @@
+class Celocli < Formula
+  desc "CLI Tool for transacting with the Celo protocol"
+  homepage "https://docs.celo.org/cli"
+  url "https://github.com/celo-org/developer-tooling/releases/download/%40celo%2Fcelocli%406.1.0/celocli-v6.1.0-ffdb836-darwin-x64.tar.xz"
+  sha256 "b86b72f0d64920d55e3780153e99372685df84d7a6b85a124469b77f099651b6"
+  version "6.1.0"
+  version_scheme 1
+
+  on_macos do
+    on_arm do
+      url "https://github.com/celo-org/developer-tooling/releases/download/%40celo%2Fcelocli%406.1.0/celocli-v6.1.0-ffdb836-darwin-arm64.tar.xz"
+      sha256 "788eae0411a95523b12ee55b6d4aeb550eba75f8802d97109c04d991334aa0f7"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/celo-org/developer-tooling/releases/download/%40celo%2Fcelocli%406.1.0/celocli-v6.1.0-ffdb836-linux-x64.tar.xz"
+      sha256 "a3a93689dce15f1e52b9696295a53baaf5ac0cad98b40ea1c2aa5bc4095b8cfe"
+    end
+    on_arm do
+      url "https://github.com/celo-org/developer-tooling/releases/download/%40celo%2Fcelocli%406.1.0/celocli-v6.1.0-ffdb836-linux-arm.tar.xz"
+      sha256 "407673a14764c3e39c78b1f103409dcc5b83e7500da1985dbcc7c49a88dfe161"
+    end
+  end
+
+  def install
+    inreplace "bin/celocli", /^CLIENT_HOME=/, "export CELOCLI_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"bin/celocli"
+
+    # bash_completion.install libexec/"autocomplete-scripts/brew/bash" => "celocli"
+    # zsh_completion.install libexec/"autocomplete-scripts/brew/zsh/_celocli"
+  end
+
+  # def caveats; <<~EOS
+  #   To use the Celo CLI's autocomplete --
+  #     Via homebrew's shell completion:
+  #       1) Follow homebrew's install instructions https://docs.brew.sh/Shell-Completion
+  #           NOTE: For zsh, as the instructions mention, be sure compinit is autoloaded
+  #                 and called, either explicitly or via a framework like oh-my-zsh.
+  #       2) Then run
+  #         $ celocli autocomplete --refresh-cache
+  #     OR
+  #     Use our standalone setup:
+  #       1) Run and follow the install steps:
+  #         $ celocli autocomplete
+  # EOS
+  # end
+
+  test do
+    system bin/"celocli", "--version"
+  end
+end


### PR DESCRIPTION
Update celocli formula to [6.1.0](https://github.com/celo-org/developer-tooling/releases/tag/%40celo%2Fcelocli%406.1.0).

🤖 _This pull-request was opened by a robot beep boop from [@celo-org](https://github.com/celo-org)_ 🤖
